### PR TITLE
Don't destroy string builder after rendering.

### DIFF
--- a/src/mustache.odin
+++ b/src/mustache.odin
@@ -1095,14 +1095,13 @@ template_eat_tokens :: proc(tmpl: ^Template, sb: ^strings.Builder) {
 
 template_render :: proc(tmpl: ^Template) -> (output: string, err: Render_Error) {
 	sb := strings.builder_make(context.temp_allocator)
-	defer strings.builder_destroy(&sb)
 
 	template_eat_tokens(tmpl, &sb)
 	rendered := strings.to_string(sb) 
 
 	if tmpl.layout != "" {
+		defer strings.builder_destroy(&sb)
 		sbl := strings.builder_make(context.temp_allocator)
-		defer strings.builder_destroy(&sbl)
 
 		// Parse the layout
 		layout_lexer: Lexer


### PR DESCRIPTION
First of all, thanks for a great package!

When using odin-http and odin-mustache, my http responses got garbled and the reason seems to be that odin-mustache destroys the string builder after rendering, and consequently the returned string.

I simply changed it so that the builder that was used to create the resulting string is not destroyed.