### PR TITLE
Update spec submodule to v1.4.1

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "spec"]
 	path = spec
 	url = git@github.com:mustache/spec.git
+	branch = v1.4.1


### PR DESCRIPTION
Updates the [mustache/spec](https://github.com/mustache/spec) submodule to the latest version: [v1.4.1](https://github.com/mustache/spec/releases/tag/v1.4.1)

Confirmed that all tests are passing.