### PR TITLE
fix: Update os API calls to use read_entire_file_from_path

### DIFF
--- a/examples/hello/hello.mustache
+++ b/examples/hello/hello.mustache
@@ -1,0 +1,11 @@
+Hello, {{name}}!
+
+Languages you know:
+{{#languages}}
+  - {{.}}
+{{/languages}}
+
+{{#show_footer}}
+---
+Rendered with odin-mustache.
+{{/show_footer}}

--- a/examples/hello/hello.odin
+++ b/examples/hello/hello.odin
@@ -1,0 +1,28 @@
+package main
+
+import "core:fmt"
+import "core:os"
+
+import mustache "../.."
+
+Person :: struct {
+	name:        string,
+	languages:   []string,
+	show_footer: bool,
+}
+
+main :: proc() {
+	data := Person{
+		name      = "World",
+		languages = {"Odin", "C", "Rust"},
+		show_footer = true,
+	}
+
+	result, err := mustache.render_from_filename("hello.mustache", data)
+	if err != nil {
+		fmt.eprintfln("render error: %v", err)
+		os.exit(1)
+	}
+
+	fmt.print(result)
+}

--- a/mustache.odin
+++ b/mustache.odin
@@ -1326,7 +1326,7 @@ render_in_layout_file :: proc(
 	allocator := context.allocator,
 ) -> (s: string, err: Render_Error) {
 	// Read layout file.
-	layout, _ := os.read_entire_file_from_filename(layout_filename, allocator)
+	layout, _ := os.read_entire_file_from_path(layout_filename, allocator)
 
 	// Parse template.
 	lexer := lexer_make(allocator)
@@ -1352,7 +1352,7 @@ render_from_filename :: proc(
 	allocator := context.allocator,
 ) -> (s: string, err: Render_Error) {
 	// Read template file.
-	src, _ := os.read_entire_file_from_filename(filename, allocator)
+	src, _ := os.read_entire_file_from_path(filename, allocator)
 
 	// Parse template.
 	lexer := lexer_make(allocator)
@@ -1379,7 +1379,7 @@ render_from_filename_in_layout :: proc(
 ) -> (s: string, err: Render_Error) {
 
 	// Read template file and trim the trailing newline.
-	src, _ := os.read_entire_file_from_filename(filename, allocator)
+	src, _ := os.read_entire_file_from_path(filename, allocator)
 	if rune(src[len(src)-1]) == '\n' {
 		src = src[0:len(src)-1]
 	}
@@ -1409,13 +1409,13 @@ render_from_filename_in_layout_file :: proc(
 ) -> (s: string, err: Render_Error) {
 
 	// Read template file and trim the trailing newline.
-	src, _ := os.read_entire_file_from_filename(filename, allocator)
+	src, _ := os.read_entire_file_from_path(filename, allocator)
 	if rune(src[len(src)-1]) == '\n' {
 		src = src[0:len(src)-1]
 	}
 
 	// Read layout file.
-	layout, _ := os.read_entire_file_from_filename(layout_filename, allocator)
+	layout, _ := os.read_entire_file_from_path(layout_filename, allocator)
 
 	// Parse template.
 	lexer := lexer_make(allocator)
@@ -1439,7 +1439,7 @@ render_with_json :: proc(
 	allocator := context.allocator,
 ) -> (s: string, err: Render_Error) {
 	// Load JSON.
-	json_src, _ := os.read_entire_file_from_filename(json_filename, allocator)
+	json_src, _ := os.read_entire_file_from_path(json_filename, allocator)
 	json_data := json.parse(json_src, allocator = allocator) or_return
 	json_root := json_data.(json.Object)
 
@@ -1465,7 +1465,7 @@ render_with_json_in_layout :: proc(
 	allocator := context.allocator,
 ) -> (s: string, err: Render_Error) {
 	// Load JSON.
-	json_src, _ := os.read_entire_file_from_filename(json_filename, allocator)
+	json_src, _ := os.read_entire_file_from_path(json_filename, allocator)
 	json_data := json.parse(json_src, allocator = allocator) or_return
 	json_root := json_data.(json.Object)
 
@@ -1492,10 +1492,10 @@ render_with_json_in_layout_file :: proc(
 	allocator := context.allocator,
 ) -> (s: string, err: Render_Error) {
 	// Read layout file.
-	layout, _ := os.read_entire_file_from_filename(layout_filename, allocator)
+	layout, _ := os.read_entire_file_from_path(layout_filename, allocator)
 
 	// Load JSON.
-	json_src, _ := os.read_entire_file_from_filename(json_filename, allocator)
+	json_src, _ := os.read_entire_file_from_path(json_filename, allocator)
 	json_data := json.parse(json_src, allocator = allocator) or_return
 	json_root := json_data.(json.Object)
 
@@ -1521,10 +1521,10 @@ render_from_filename_with_json :: proc(
 	allocator := context.allocator,
 ) -> (s: string, err: Render_Error) {
 	// Read template file.
-	src, _ := os.read_entire_file_from_filename(filename, allocator)
+	src, _ := os.read_entire_file_from_path(filename, allocator)
 
 	// Load JSON.
-	json_src, _ := os.read_entire_file_from_filename(json_filename, allocator)
+	json_src, _ := os.read_entire_file_from_path(json_filename, allocator)
 	json_data := json.parse(json_src) or_return
 	defer json.destroy_value(json_data)
 	json_root := json_data.(json.Object)
@@ -1551,13 +1551,13 @@ render_from_filename_with_json_in_layout :: proc(
 	allocator := context.allocator,
 ) -> (s: string, err: Render_Error) {
 	// Read template file and trim the trailing newline.
-	src, _ := os.read_entire_file_from_filename(filename, allocator)
+	src, _ := os.read_entire_file_from_path(filename, allocator)
 	if rune(src[len(src)-1]) == '\n' {
 		src = src[0:len(src)-1]
 	}
 
 	// Load JSON.
-	json_src, _ := os.read_entire_file_from_filename(json_filename, allocator)
+	json_src, _ := os.read_entire_file_from_path(json_filename, allocator)
 	json_data := json.parse(json_src, allocator = allocator) or_return
 	json_root := json_data.(json.Object)
 
@@ -1584,16 +1584,16 @@ render_from_filename_with_json_in_layout_file :: proc(
 	allocator := context.allocator,
 ) -> (s: string, err: Render_Error) {
 	// Read template file and trim the trailing newline.
-	src, _ := os.read_entire_file_from_filename(filename, allocator)
+	src, _ := os.read_entire_file_from_path(filename, allocator)
 	if rune(src[len(src)-1]) == '\n' {
 		src = src[0:len(src)-1]
 	}
 
 	// Read layout file.
-	layout, _ := os.read_entire_file_from_filename(layout_filename, allocator)
+	layout, _ := os.read_entire_file_from_path(layout_filename, allocator)
 
 	// Load JSON.
-	json_src, _ := os.read_entire_file_from_filename(json_filename, allocator)
+	json_src, _ := os.read_entire_file_from_path(json_filename, allocator)
 	json_data := json.parse(json_src, allocator = allocator) or_return
 	json_root := json_data.(json.Object)
 

--- a/mustache_test.odin
+++ b/mustache_test.odin
@@ -73,8 +73,8 @@ load_json :: proc(val: json.Value) -> (loaded: JSON_Data) {
 load_spec :: proc(filename: string) -> (json.Value) {
 	context.allocator = context.temp_allocator
 
-	data, ok := os.read_entire_file_from_filename(filename)
-	if !ok {
+	data, read_err := os.read_entire_file_from_path(filename, context.allocator)
+	if read_err != nil {
 		fmt.println("Failed to load the file!")
 		os.exit(1)
 	}


### PR DESCRIPTION
Replace removed read_entire_file_from_filename with read_entire_file_from_path to fix compilation against latest Odin core:os API. (odin version dev-2026-04:608709693)